### PR TITLE
feat: Implement logout functionality and enhance cache control for au…

### DIFF
--- a/app/(auth)/login/page.jsx
+++ b/app/(auth)/login/page.jsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-import Link from "next/link";
 import { useAuth } from "@/lib/auth-context";
 import { LoginForm } from "@/components/auth/login-form";
 import {
@@ -13,10 +11,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import Link from "next/link";
 
 export default function LoginPage() {
   const { isAuthenticated, isLoading } = useAuth();
-  const router = useRouter();
 
   useEffect(() => {
     console.log("[LoginPage] Auth state:", { isAuthenticated, isLoading });
@@ -24,9 +22,35 @@ export default function LoginPage() {
       console.log(
         "[LoginPage] User is authenticated, redirecting to dashboard"
       );
-      router.replace("/dashboard");
+      // Use window.location for hard redirect to clear cache
+      window.location.href = "/dashboard";
     }
-  }, [isAuthenticated, isLoading, router]);
+  }, [isAuthenticated, isLoading]);
+
+  // Add no-cache meta tags
+  useEffect(() => {
+    // Set meta tags to prevent caching
+    const metaCache = document.createElement("meta");
+    metaCache.httpEquiv = "Cache-Control";
+    metaCache.content = "no-cache, no-store, must-revalidate";
+    document.head.appendChild(metaCache);
+
+    const metaPragma = document.createElement("meta");
+    metaPragma.httpEquiv = "Pragma";
+    metaPragma.content = "no-cache";
+    document.head.appendChild(metaPragma);
+
+    const metaExpires = document.createElement("meta");
+    metaExpires.httpEquiv = "Expires";
+    metaExpires.content = "0";
+    document.head.appendChild(metaExpires);
+
+    return () => {
+      document.head.removeChild(metaCache);
+      document.head.removeChild(metaPragma);
+      document.head.removeChild(metaExpires);
+    };
+  }, []);
 
   if (isLoading) {
     return (
@@ -36,8 +60,14 @@ export default function LoginPage() {
     );
   }
 
-  // Don't prevent rendering if authenticated - let the useEffect handle redirect
-  // This prevents a flash of login form after successful login
+  // Don't render if authenticated - prevents flash of login form
+  if (isAuthenticated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-muted-foreground">Redirecting...</p>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">

--- a/app/(auth)/logout/page.jsx
+++ b/app/(auth)/logout/page.jsx
@@ -1,26 +1,19 @@
-"use client"
+"use client";
 
-import { useEffect } from "react"
-import { useRouter } from "next/navigation"
+import { useEffect } from "react";
+import { useAuth } from "@/lib/auth-context";
 
 export default function LogoutPage() {
-  const router = useRouter()
+  const { logout } = useAuth();
 
   useEffect(() => {
-    // Clear all auth data
-    localStorage.removeItem("inventory_auth_token")
-    localStorage.removeItem("inventory_user")
-    document.cookie = "inventory_auth_token=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT"
-    
-    // Redirect to login
-    setTimeout(() => {
-      router.replace("/login")
-    }, 500)
-  }, [router])
+    // Use the centralized logout function
+    logout();
+  }, [logout]);
 
   return (
     <div className="flex items-center justify-center min-h-screen">
       <p>Logging out...</p>
     </div>
-  )
+  );
 }

--- a/lib/auth-context.js
+++ b/lib/auth-context.js
@@ -50,12 +50,26 @@ export function AuthProvider({ children }) {
               "[AuthContext] Token validation failed:",
               error.message
             );
+            // Clear all auth data
             localStorage.removeItem("inventory_auth_token");
             localStorage.removeItem("inventory_user");
             document.cookie =
-              "inventory_auth_token=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT";
+              "inventory_auth_token=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=Strict";
             setToken(null);
             setUser(null);
+
+            // If we're on a protected route, redirect to login
+            if (
+              typeof window !== "undefined" &&
+              window.location.pathname !== "/" &&
+              window.location.pathname !== "/login" &&
+              window.location.pathname !== "/register"
+            ) {
+              console.log(
+                "[AuthContext] Redirecting to login due to invalid token"
+              );
+              window.location.href = "/login";
+            }
           }
         } else {
           console.log("[AuthContext] No stored credentials found");
@@ -123,13 +137,40 @@ export function AuthProvider({ children }) {
   };
 
   const logout = async () => {
-    setToken(null);
-    setUser(null);
-    localStorage.removeItem("inventory_auth_token");
-    localStorage.removeItem("inventory_user");
-    document.cookie =
-      "inventory_auth_token=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT";
-    await router.replace("/login");
+    try {
+      console.log("[AuthContext] Starting logout...");
+
+      // Clear state first
+      setToken(null);
+      setUser(null);
+
+      // Clear localStorage
+      localStorage.removeItem("inventory_auth_token");
+      localStorage.removeItem("inventory_user");
+
+      // Clear all cookies
+      document.cookie =
+        "inventory_auth_token=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=Strict";
+
+      // Call logout endpoint to clear server-side cookie
+      try {
+        await apiClient.post(AUTH_ENDPOINTS.LOGOUT, {});
+      } catch (error) {
+        console.log(
+          "[AuthContext] Logout API call failed (this is okay):",
+          error.message
+        );
+      }
+
+      console.log("[AuthContext] Logout complete, redirecting to login...");
+
+      // Force a hard redirect to login page to clear all caches
+      window.location.href = "/login";
+    } catch (error) {
+      console.error("[AuthContext] Logout error:", error);
+      // Even if logout fails, redirect to login
+      window.location.href = "/login";
+    }
   };
 
   const register = async (data) => {

--- a/lib/config/api-endpoints.js
+++ b/lib/config/api-endpoints.js
@@ -3,7 +3,8 @@
  * Centralized API endpoint paths for the entire application
  */
 
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000/api/v1";
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000/api/v1";
 
 // Authentication Endpoints
 export const AUTH_ENDPOINTS = {
@@ -11,6 +12,7 @@ export const AUTH_ENDPOINTS = {
   REGISTER: "/auth/register",
   ME: "/auth/me",
   REFRESH: "/auth/refresh",
+  LOGOUT: "/auth/logout",
   CREATE_USER: "/auth/users/create",
 };
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -29,6 +29,31 @@ const nextConfig = {
           { key: "Expires", value: "0" },
         ],
       },
+      {
+        // Apply no-cache headers to all authenticated pages
+        source:
+          "/(dashboard|inventory|assignments|livestock|feeds|locations|users|maintenance|reservations|approvals|audit-logs|reports|settings|categories|stock-movements|stock-transfers|suppliers|purchase-orders|product-assignments|notifications)/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-store, no-cache, must-revalidate, private",
+          },
+          { key: "Pragma", value: "no-cache" },
+          { key: "Expires", value: "0" },
+        ],
+      },
+      {
+        // Apply no-cache headers to auth pages
+        source: "/(login|register|logout)",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-store, no-cache, must-revalidate, private",
+          },
+          { key: "Pragma", value: "no-cache" },
+          { key: "Expires", value: "0" },
+        ],
+      },
     ];
   },
   // API routes will be handled by custom server

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -170,6 +170,40 @@ exports.getCurrentUser = async (req, res) => {
   }
 };
 
+// Logout
+exports.logout = async (req, res) => {
+  try {
+    console.log("[Auth Controller] Logout request");
+
+    // Clear the httpOnly cookie
+    res.clearCookie("inventory_auth_token", {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "strict",
+      path: "/",
+    });
+
+    // Set cache-control headers to prevent caching
+    res.set({
+      "Cache-Control": "no-store, no-cache, must-revalidate, private",
+      Pragma: "no-cache",
+      Expires: "0",
+    });
+
+    console.log("[Auth Controller] Logout successful");
+    res.json({
+      success: true,
+      message: "Logged out successfully",
+    });
+  } catch (error) {
+    console.error("Logout error:", error);
+    res.status(500).json({
+      success: false,
+      message: "Failed to logout",
+    });
+  }
+};
+
 // Refresh token
 exports.refreshToken = async (req, res) => {
   try {

--- a/server/routes/auth.routes.js
+++ b/server/routes/auth.routes.js
@@ -1,15 +1,26 @@
-const express = require('express');
+const express = require("express");
 const router = express.Router();
-const authController = require('../controllers/auth.controller');
-const { authMiddleware } = require('../middleware/auth');
-const { validate, authValidationRules } = require('../middleware/validate');
+const authController = require("../controllers/auth.controller");
+const { authMiddleware } = require("../middleware/auth");
+const { validate, authValidationRules } = require("../middleware/validate");
 
 // Public routes with validation
-router.post('/register', authValidationRules.register, validate, authController.register);
-router.post('/login', authValidationRules.login, validate, authController.login);
+router.post(
+  "/register",
+  authValidationRules.register,
+  validate,
+  authController.register
+);
+router.post(
+  "/login",
+  authValidationRules.login,
+  validate,
+  authController.login
+);
+router.post("/logout", authController.logout);
 
 // Protected routes
-router.get('/me', authMiddleware, authController.getCurrentUser);
-router.post('/refresh', authMiddleware, authController.refreshToken);
+router.get("/me", authMiddleware, authController.getCurrentUser);
+router.post("/refresh", authMiddleware, authController.refreshToken);
 
 module.exports = router;


### PR DESCRIPTION
This pull request implements comprehensive improvements to authentication logout and cache control throughout the application. The main goals are to ensure a secure logout process, prevent authenticated or sensitive pages from being cached, and streamline authentication state handling on both the client and server sides.

**Authentication and Logout Improvements:**

* Added a dedicated `logout` endpoint on the server (`/auth/logout`) that clears the authentication cookie and sets no-cache headers. [[1]](diffhunk://#diff-8adda704e611193cd300636434a6063f53fc51b2a3cdfdf139e0ef7ed4fcbfe2R173-R206) [[2]](diffhunk://#diff-43592be6401a86c31d18482bcac2b4e70dc360534812666ba70a1f4afe1a097fL1-R24)
* Refactored the client-side logout process to use a centralized `logout` method in `auth-context.js`, which:
  - Clears client state, local storage, and cookies
  - Calls the new logout API endpoint
  - Redirects to the login page with a hard reload to clear caches [[1]](diffhunk://#diff-27a8bc908af2f73091fc2db41a25bbf2bb7337f61d55be245c985c5831b6b133R140-R173) [[2]](diffhunk://#diff-499d2a3abf91c5c19eda2fe676258cdae90bfbed76264ed42cfa616c12ccc210L1-R18)
* Updated the login page logic to perform a hard redirect to the dashboard if already authenticated and to add meta tags to prevent caching of the login page. [[1]](diffhunk://#diff-799776db0a96ea343fb7abb90ac5e95b6bda68afc1533d57f82057595090e4e4R14-R53) [[2]](diffhunk://#diff-799776db0a96ea343fb7abb90ac5e95b6bda68afc1533d57f82057595090e4e4L39-R70)

**Cache Control and Security Enhancements:**

* Added no-cache headers to all authenticated and authentication-related routes in `next.config.mjs` to prevent browser and intermediary caching.
* Updated the middleware proxy to set cache-control headers on all responses and expanded the list of protected routes. [[1]](diffhunk://#diff-00c3ab77cd53461a974f25d2dba333a57c9907761e0a6c8e9326ebb107f265e2L3-R27) [[2]](diffhunk://#diff-00c3ab77cd53461a974f25d2dba333a57c9907761e0a6c8e9326ebb107f265e2R45-R75)
* Ensured that after failed token validation, all auth data is cleared and the user is redirected to the login page if on a protected route.

**Supporting Changes:**

* Added the new `LOGOUT` endpoint to the centralized API endpoints configuration.
* Minor code style and consistency improvements across touched files.

These changes together ensure that authentication state is handled more securely and consistently, and that sensitive pages are never cached, reducing the risk of unauthorized access.

**Most important changes:**

**Authentication and Logout:**
- Added a new `/auth/logout` endpoint on the server to clear the authentication cookie and set no-cache headers. [[1]](diffhunk://#diff-8adda704e611193cd300636434a6063f53fc51b2a3cdfdf139e0ef7ed4fcbfe2R173-R206) [[2]](diffhunk://#diff-43592be6401a86c31d18482bcac2b4e70dc360534812666ba70a1f4afe1a097fL1-R24)
- Centralized and improved the client-side logout process in `auth-context.js`, including calling the new API endpoint and using a hard redirect to clear caches. [[1]](diffhunk://#diff-27a8bc908af2f73091fc2db41a25bbf2bb7337f61d55be245c985c5831b6b133R140-R173) [[2]](diffhunk://#diff-499d2a3abf91c5c19eda2fe676258cdae90bfbed76264ed42cfa616c12ccc210L1-R18)

**Cache Control:**
- Added cache-control headers to all authenticated and authentication-related pages in `next.config.mjs` to prevent caching.
- Updated the middleware proxy to always set no-cache headers and expanded protected route coverage. [[1]](diffhunk://#diff-00c3ab77cd53461a974f25d2dba333a57c9907761e0a6c8e9326ebb107f265e2L3-R27) [[2]](diffhunk://#diff-00c3ab77cd53461a974f25d2dba333a57c9907761e0a6c8e9326ebb107f265e2R45-R75)
- Added meta tags to the login page to prevent caching and improved redirect logic for authenticated users. [[1]](diffhunk://#diff-799776db0a96ea343fb7abb90ac5e95b6bda68afc1533d57f82057595090e4e4R14-R53) [[2]](diffhunk://#diff-799776db0a96ea343fb7abb90ac5e95b6bda68afc1533d57f82057595090e4e4L39-R70)…thentication routes