### PR TITLE
fix: Temporarily hide notifications feature due to required fixes

### DIFF
--- a/components/layout/sidebar.jsx
+++ b/components/layout/sidebar.jsx
@@ -120,12 +120,13 @@ const sidebarItems = [
     icon: CheckCircle,
     roles: ["admin", "manager", "employee"],
   },
-  {
-    name: "Notifications",
-    href: "/notifications",
-    icon: Bell,
-    roles: ["admin", "manager", "employee"],
-  },
+  // Temporarily hidden - notifications feature needs fixes
+  // {
+  //   name: "Notifications",
+  //   href: "/notifications",
+  //   icon: Bell,
+  //   roles: ["admin", "manager", "employee"],
+  // },
   {
     name: "Reports",
     href: "/reports",


### PR DESCRIPTION
This pull request makes a minor change to the sidebar navigation by temporarily hiding the "Notifications" menu item until the feature is fixed. No other changes are included.

- Temporarily commented out the "Notifications" sidebar item in `sidebar.jsx` to hide it from users while the feature is being fixed.