### PR TITLE
Dev

### DIFF
--- a/components/layout/sidebar.jsx
+++ b/components/layout/sidebar.jsx
@@ -120,12 +120,13 @@ const sidebarItems = [
     icon: CheckCircle,
     roles: ["admin", "manager", "employee"],
   },
-  {
-    name: "Notifications",
-    href: "/notifications",
-    icon: Bell,
-    roles: ["admin", "manager", "employee"],
-  },
+  // Temporarily hidden - notifications feature needs fixes
+  // {
+  //   name: "Notifications",
+  //   href: "/notifications",
+  //   icon: Bell,
+  //   roles: ["admin", "manager", "employee"],
+  // },
   {
     name: "Reports",
     href: "/reports",


### PR DESCRIPTION
This pull request makes a small change to the sidebar navigation in `sidebar.jsx` by temporarily hiding the Notifications menu item while the feature is being fixed. No other changes are included.

- Commented out the `Notifications` sidebar item in `sidebar.jsx` to temporarily remove it from the UI, with a note explaining the reason.